### PR TITLE
Add logic to support execute-next directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ If you want to skip the extra layer added by the proxy, you can always apply the
 
 ![](./images/deployment-nr.png "Deployment Architecture - Not Recommended")
 
+This option requires to set an additional flag "appliedOnApi". Please see ["Usage"](###Usage).
+
 But this approach may lead to a management nightmare, where deprecation and retirement of APIs become an almost impossible task. See ["Deprecation and Retirement"](###Deprecation-and-retirement) section.
 
 ### Deprecation and retirement
@@ -60,12 +62,14 @@ After publishing to Exchange, follow these steps to apply the policy to an exist
 | Protocol (Canary) | Details the protocol for the canary version |
 | Path (Canary) | Details the path for the canary version |
 | Weight (Canary) | Details the weight for the canary version. Represents a percentage that is calculated taking into account a sample of 10 requests. For example: 50 indicates that 5 requests out of 10 will be routed to this endpoint |
+| appliedOnApi | Select this option only if the policy is applied on the base API (original) instead of on a proxy. This forces the <http-policy:execute-next> directive. See https://docs.mulesoft.com/api-manager/2.x/custom-policy-4-reference#basic-xml-structure for further details. |
 | sessionStickinessSupport | Indicates if the session stickiness capability is enabled (TO-DO) |
 | Session Stickiness Header Expression | If session stickiness is enabled, this DW expression represents how to access the header that contains the key used to track the session stickiness (TO-DO) |
 | Override Object Store Settings? | Select this option to override the default Object Store. The default is false. |
 | Is the Object Store persistent? | If checked, uses a persistent Object Store ) |
 | Object Store's entry TTL | The entry timeout. Default value is 1 (hour) ) |
 | Object Store's entry TTL unit | The time unit. Default value is "HOURS". ) |
+
 
 #### Development
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@ There are no limitations imposed by the use of this policy regarding the deploym
 
 ![](./images/deployment.png "Deployment Architecture")
 
-From the above, a proxy is deployed on top of both versions (original and canary) in order to centralize communication, providing an abstraction and improving understanding from the point of view of networking and traffic management. Please see ["Limitations"](###Limitations) and ["Known Issues"](###Known-Issues) sections.
+From the above, a proxy is deployed on top of both versions (original and canary) in order to centralize communication, providing an abstraction and improving understanding from the point of view of networking and traffic management. Please see ["Limitations"](###Limitations).
 
 If you want to skip the extra layer added by the proxy, you can always apply the policy on top of the original (baseline) application:
 
 ![](./images/deployment-nr.png "Deployment Architecture - Not Recommended")
 
-This option requires to set an additional flag "appliedOnApi". Please see ["Usage"](###Usage).
+This option requires to set an additional flag "appliedOnApi". Please see ["Usage"](###Usage). Additionally, it is important to note that if this option is enabled, the collection of metrics does not work.
+
 
 But this approach may lead to a management nightmare, where deprecation and retirement of APIs become an almost impossible task. See ["Deprecation and Retirement"](###Deprecation-and-retirement) section.
 
@@ -62,7 +63,7 @@ After publishing to Exchange, follow these steps to apply the policy to an exist
 | Protocol (Canary) | Details the protocol for the canary version |
 | Path (Canary) | Details the path for the canary version |
 | Weight (Canary) | Details the weight for the canary version. Represents a percentage that is calculated taking into account a sample of 10 requests. For example: 50 indicates that 5 requests out of 10 will be routed to this endpoint |
-| appliedOnApi | Select this option only if the policy is applied on the base API (original) instead of on a proxy. This forces the <http-policy:execute-next> directive. See https://docs.mulesoft.com/api-manager/2.x/custom-policy-4-reference#basic-xml-structure for further details. |
+| appliedOnApi | Select this option only if the policy is applied on the base API (original) instead of on a proxy. This forces the <http-policy:execute-next> directive. See https://docs.mulesoft.com/api-manager/2.x/custom-policy-4-reference#basic-xml-structure for further details. When this option is checked, metrics gathering won't works|
 | sessionStickinessSupport | Indicates if the session stickiness capability is enabled (TO-DO) |
 | Session Stickiness Header Expression | If session stickiness is enabled, this DW expression represents how to access the header that contains the key used to track the session stickiness (TO-DO) |
 | Override Object Store Settings? | Select this option to override the default Object Store. The default is false. |
@@ -90,7 +91,7 @@ In Debug mode, it will print the following checkpoints:
 - Flag indicating the Traffic Object Store will be updated
 
 ### Metrics
-The policy incorporates the possibility of collecting usage metrics to later be used in a Canary Analysis process.
+The policy incorporates the possibility of collecting usage metrics to later be used in a Canary Analysis process. This option only works if the Canary is applied on top of a proxy.
 
 #### To enable the Metrics
 - Enable "Capture Raw Usage Metrics?" by clicking on the radio button, while applying the policy
@@ -136,7 +137,6 @@ If you want to use this solution anyway, this approach leads to the following pr
 - Extra component is required (proxy), adding more hops to the process -OPTIONAL if proxy approach was chosen-. In a typical API-Led approach, having an additional step on top of the existing 3 layers might be counterproductive with defined SLAs and SLOs
 - Adds environment promotion complexity as part of the CI/CD pipelines
 - Deprecation and Retirement becomes a time consuming task (more than usual!)
-- The underlying proxy logic is never used. ```<http-policy:execute-next />``` is never invoked.
 
 ### Contribution
 

--- a/canary-release-mule4.yaml
+++ b/canary-release-mule4.yaml
@@ -109,6 +109,12 @@ configuration:
     allowMultiple: false
     minimumValue: 5
     maximumValue: 100
+  - propertyName: appliedOnApi
+    name: Applied on the base API?
+    description: Select this option only if the policy is applied on the base API (original) instead of on a proxy. This forces the <http-policy:execute-next> directive. See https://docs.mulesoft.com/api-manager/2.x/custom-policy-4-reference#basic-xml-structure for further details.
+    type: boolean
+    optional: true
+    defaultValue: false
   - propertyName: sessionStickinessSupport
     name: Support Session Stickness?
     description: Select this option to support session stickiness using an HTTP header

--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,10 @@
     <groupId>{{ReplaceMeWithYourOrgID}}</groupId>
     <artifactId>canary-release-mule4</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-
     <name>canary-release-mule4</name>
     <description>A custom policy to support canary releases</description>
 
-    <packaging>mule-policy</packaging>  
+    <packaging>mule-policy</packaging>
 
     <properties>
         <mule.maven.plugin.version>3.3.6</mule.maven.plugin.version>

--- a/src/main/mule/template.xml
+++ b/src/main/mule/template.xml
@@ -48,9 +48,9 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                   ['/metrics', '/favicon.ico'] contains attributes.rawRequestPath]">
                     <logger message="Retrieving and printing stored metrics" level="DEBUG" category="com.mule.policies.canary" />
                     <os:retrieve-all objectStore="metrics"/>
-                    <set-payload value="#[%dw 2.0 output application/json --- payload]"/>                              
+                    <set-payload value="#[%dw 2.0 output application/json --- payload]"/>
                 </when>
-                <otherwise>    
+                <otherwise>
                     {{#if captureUsageMetrics}}
                         <set-variable value="#[%dw 2.0 output application/java --- now()]" variableName="startTime"/>
                         <set-variable value="0" variableName="canary"/>
@@ -117,18 +117,22 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                                           ---
                                           vars.destination.url contains ( vars.protocol ++'://'++ vars.host ++':'++ vars.port ++ vars.path ) ]">
                           <logger message="Routing to original" level="DEBUG" category="com.mule.policies.canary" />
-                          <http:request config-ref="http-request-config"
-                                        method="#[attributes.method]"
-                                        path="#[%dw 2.0
-                                                import * from dw::core::URL
-                                                ---
-                                                parseURI(vars.destination.url).path]">
-                              <http:uri-params>#[attributes.uriParams]</http:uri-params>
-                              <http:query-params>#[attributes.queryParams]</http:query-params>
-                              <http:response-validator>
-                                  <http:success-status-code-validator values="0..599"/>
-                              </http:response-validator>
-                          </http:request>
+                          {{#if appliedOnApi}}
+                              <http-policy:execute-next/>
+                          {{else}}
+                              <http:request config-ref="http-request-config"
+                                            method="#[attributes.method]"
+                                            path="#[%dw 2.0
+                                                    import * from dw::core::URL
+                                                    ---
+                                                    parseURI(vars.destination.url).path]">
+                                  <http:uri-params>#[attributes.uriParams]</http:uri-params>
+                                  <http:query-params>#[attributes.queryParams]</http:query-params>
+                                  <http:response-validator>
+                                      <http:success-status-code-validator values="0..599"/>
+                                  </http:response-validator>
+                              </http:request>
+                          {{/if}}
                       </when>
                       <otherwise>
                         <logger message="Routing to canary" level="DEBUG" category="com.mule.policies.canary" />
@@ -192,7 +196,7 @@ http://www.mulesoft.org/schema/mule/os/current/mule-os.xsd">
                             canary: vars.canary
                         }]
                    </os:value>
-                </os:store>                         
+                </os:store>
             </when>
         </choice>
     </flow>


### PR DESCRIPTION
Fixes #7 

Manual test executed:

- Deployed two identical APIs to Cloudhub. One named "base" and the other "canary"
- Applied the new version of the policy as 50/50 weights
- Executed 10 requests from Postman. Expected result: 5 request to base API and 5 request to canary API
- Manually check the results on Runtime Manager Logs:

![image](https://user-images.githubusercontent.com/50634447/149523609-32b6a95b-ef1f-4df4-8fd3-130e5b8a8171.png)

![image](https://user-images.githubusercontent.com/50634447/149523707-c1063220-5996-4c0e-b44a-80c671878078.png)

